### PR TITLE
MNT: Relax dependencies, and don't use run_constrained anymore

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -22,7 +22,7 @@ jobs:
   # configure qemu binfmt-misc running.  This allows us to run docker containers 
   # embedded qemu-static
   - script: |
-      docker run --rm --privileged multiarch/qemu-user-static:register
+      docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
       ls /proc/sys/fs/binfmt_misc/
     condition: not(startsWith(variables['CONFIG'], 'linux_64'))
     displayName: Configure binfmt_misc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,13 +7,12 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   entry_points:
     - immv          = fsl.scripts.immv:main
@@ -25,26 +24,22 @@ build:
     - fsl_ents      = fsl.scripts.fsl_ents:main
 
 requirements:
-  build:
-    - python
-    - pip
   host:
     - python
     - pip
     - numpy
   run:
     - python
-    - deprecation >=1.*,<=2.*
+    - deprecation >=1.*
     - {{ pin_compatible('numpy') }}
-    - scipy >=0.18,<2
+    - scipy >=0.18
     - nibabel 2.*
     - six 1.*
-  run_constrained:
-    - indexed_gzip >=0.7,<1.*
-    - wxpython <4.1
-    - trimesh >=2.22.28,<3
-    - rtree 0.8.3
-    - dcm2niix 1.0.20180622
+    - indexed_gzip >=0.7
+    - wxpython >=4
+    - trimesh >=2.22.28
+    - rtree 0.8.3.*
+    - dcm2niix
 
 test:
   source_files:
@@ -54,10 +49,10 @@ test:
     - coverage 4.*
     - pytest 3.*
     - pytest-cov 2.*
-    - trimesh >= 2.22.28,<3
-    - rtree 0.8.3
-    - indexed_gzip >=0.7,<1.*
-    - dcm2niix 1.0.20180622
+    - trimesh >=2.22.28
+    - rtree 0.8.3.*
+    - indexed_gzip >=0.7
+    - dcm2niix
   commands:
     - pytest -x -v --cov=fsl -m "not (wxtest or unixtest or longtest or fsltest or noroottest)"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - scipy >=0.18
     - nibabel 2.*
     - six 1.*
+  run_constrained:
     - indexed_gzip >=0.7
     - wxpython >=4
     - trimesh >=2.22.28
@@ -54,7 +55,7 @@ test:
     - indexed_gzip >=0.7
     - dcm2niix
   commands:
-    - pytest -x -v --cov=fsl -m "not (wxtest or unixtest or longtest or fsltest or noroottest)"
+    - pytest -x -v --cov=fsl -m "not (wxtest or unixtest or longtest or fsltest or noroottest)" tests
 
 
 about:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
